### PR TITLE
deps(deps): bump react and react-dom from 19.0.0 to 19.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "framer-motion": "^12.8.0",
     "ioredis": "^5.6.1",
     "next": "15.5.4",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
     "redis": "^5.8.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Bumps the react and react-dom dependencies from 19.0.0 to 19.2.0 to ensure version consistency and compatibility with Next.js 15.5.x.

- Both React and React-DOM must match exactly to prevent build-time version mismatch errors.
- This update resolves the error: "Incompatible React versions: The 'react' and 'react-dom' packages must have the exact same version."

No other dependencies are modified in this commit.